### PR TITLE
Fix Create Channel

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    # Disable patch checks, which is rather flaky
+    patch:
+      default:
+        enabled: no
+        if_not_found: success
+    project:
+      default:
+        threshold: 3

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ This repository implements the 4 different service methods offered by gRPC.
    * Note: If venv is not on your system, the terminal will prompt you with the command to pip install it
 3. Run Pytests (without/with verbosity):
    1. Enter arithmetic_python_client package folder ```cd libs/arithmetic_python_client/```
-   2. If you have built the Docker containers: ```pytest pytest/``` / ```pytest -vvv -s --log-cli-level=INFO pytest/```
+   2. **Recommended** - If you have built the Docker containers: ```pytest pytest/``` / ```pytest -vvv -s --log-cli-level=INFO pytest/```
    3. If you have built from source: ```pytest  --use-local-server pytest/``` / ```pytest -vvv -s --log-cli-level=INFO --use-local-server pytest/```
 4. **With the Arithmetic server running** you can launch the interactive Python clients. **In the git root directory**:
    1. Average: ```./scripts/launch_interactive_python_client.py average```

--- a/libs/arithmetic_python_client/pytest/test_python_client.py
+++ b/libs/arithmetic_python_client/pytest/test_python_client.py
@@ -1,0 +1,16 @@
+import time
+
+from arithmetic_python_client.python_client import PythonClient
+
+
+def test_create_connect_channel_timeout() -> None:
+    NON_EXISTING_ADDRESS: str = "[::]:123456"
+    TIMEOUT: float = 1.0
+    inactive_client: PythonClient = PythonClient()
+
+    start_time = time.time()
+    result = inactive_client._create_connect_channel(address_with_port=NON_EXISTING_ADDRESS, timeout=TIMEOUT)
+    end_time = time.time()
+
+    assert result is None
+    assert (end_time - start_time) > TIMEOUT

--- a/libs/arithmetic_python_client/pytest/testing_helpers.py
+++ b/libs/arithmetic_python_client/pytest/testing_helpers.py
@@ -1,5 +1,6 @@
 import docker
 import subprocess
+import time
 
 from arithmetic_python_client import MaxClient, PerformPrimeNumberDecompositionClient
 
@@ -22,3 +23,4 @@ class ArithmeticServerProcess:
         except docker.errors.APIError:
             # Handle case where docker container is used and already killed during pytest
             pass
+        time.sleep(0.2)    # Provide some time for kill to be processed


### PR DESCRIPTION
Fix bug where a timeout when creating a ready channel will result in a stray daemon thread.
Added unit test for this and a fixture to ensure all tests exit with only the main thread